### PR TITLE
Fix fading problem when only two slides

### DIFF
--- a/flickity-fade.js
+++ b/flickity-fade.js
@@ -159,7 +159,7 @@ proto.fadeSlides = function() {
   var fadeSlideB = this.slides[ indexes.b ];
   var distance = this.wrapDifference( fadeSlideA.target, fadeSlideB.target );
   var progress = this.wrapDifference( fadeSlideA.target, -this.x );
-  progress = progress / distance;
+  progress = Math.abs(progress / distance);
 
   fadeSlideA.setOpacity( 1 - progress );
   fadeSlideB.setOpacity( progress );


### PR DESCRIPTION
Thanks for the great plugin.

I found a small problem and will send you a report and suggested fix.

## Reproduction

When there are two slides, when returning from the second slide to the first, the first slide is displayed instantly instead of fading (this problem did not seem to be reproduced when there were three or more slides).

## Solution
I haven't investigated it too closely, but I think it is caused by the negative value of "progress".

If there is a better fix, it's OK not to merge.